### PR TITLE
Remove unnecessary framework dependencies

### DIFF
--- a/Bluewire.Common.Console.Client/Bluewire.Common.Console.Client.csproj
+++ b/Bluewire.Common.Console.Client/Bluewire.Common.Console.Client.csproj
@@ -49,12 +49,7 @@
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Cmd.cs" />

--- a/Bluewire.Common.Console.Client/Properties/AssemblyInfo.cs
+++ b/Bluewire.Common.Console.Client/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c66a3f12-79e2-46bd-8aab-d75414e14b6c")]
 
-[assembly: AssemblyVersion("9.1.0")]
-[assembly: AssemblyFileVersion("9.1.0")]
+[assembly: AssemblyVersion("9.1.1")]
+[assembly: AssemblyFileVersion("9.1.1")]

--- a/Bluewire.Common.Console.NUnit3/Bluewire.Common.Console.NUnit3.csproj
+++ b/Bluewire.Common.Console.NUnit3/Bluewire.Common.Console.NUnit3.csproj
@@ -36,13 +36,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Filesystem\PathSegmentSanitiser.cs" />

--- a/Bluewire.Common.Console.NUnit3/Properties/AssemblyInfo.cs
+++ b/Bluewire.Common.Console.NUnit3/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3254e82f-4b75-4984-8f08-e015da88a656")]
 
-[assembly: AssemblyVersion("9.1.4")]
-[assembly: AssemblyFileVersion("9.1.4")]
+[assembly: AssemblyVersion("9.1.5")]
+[assembly: AssemblyFileVersion("9.1.5")]


### PR DESCRIPTION
Bluewire.Common.Console.Client: 9.1.0 -> 9.1.1
Bluewire.Common.Console.NUnit3: 9.1.4 -> 9.1.5