### PR TITLE
Provide more configuration options when hosting daemons

### DIFF
--- a/Bluewire.Common.Console/Properties/AssemblyInfo.cs
+++ b/Bluewire.Common.Console/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Bluewire.Common.Console.UnitTests")]
 
-[assembly: AssemblyVersion("10.0.0")]
-[assembly: AssemblyFileVersion("10.0.0")]
+[assembly: AssemblyVersion("10.1.0")]
+[assembly: AssemblyFileVersion("10.1.0")]


### PR DESCRIPTION
* Enable the 'original' configuration file to be read.
* Provide a means of writing external configuration files at paths
  relative to the main one.

Bluewire.Common.Console: 10.0.0 -> 10.1.0