### PR TITLE
Fix handling of WaitHandles as Tasks when no timeout is specified

### DIFF
--- a/Bluewire.Common.Console/Daemons/TaskHelpers.cs
+++ b/Bluewire.Common.Console/Daemons/TaskHelpers.cs
@@ -8,11 +8,28 @@ namespace Bluewire.Common.Console.Daemons
     {
         public static Task AsTask(this WaitHandle waitHandle, CancellationToken token = default(CancellationToken))
         {
-            return AsTask(waitHandle, TimeSpan.FromMilliseconds(Int32.MaxValue), token);
+            // Infinite timeout:
+            return AsTask(waitHandle, -1, token);
         }
 
-        public static async Task AsTask(this WaitHandle waitHandle, TimeSpan limit, CancellationToken token = default(CancellationToken))
+        public static Task AsTask(this WaitHandle waitHandle, TimeSpan limit, CancellationToken token = default(CancellationToken))
         {
+            return AsTask(waitHandle, (long)limit.TotalMilliseconds, token);
+        }
+
+        private static async Task AsTask(WaitHandle waitHandle, long limitMilliseconds, CancellationToken token = default(CancellationToken))
+        {
+            // Complete immediately if possible.
+            // Simplifies mocking a single-threaded TaskScheduler, since it removes the need to tolerate continuations
+            // being queued from other threads eg. the threadpool.
+            token.ThrowIfCancellationRequested();
+            if (waitHandle.WaitOne(TimeSpan.Zero))
+            {
+                // In case of races when waiting on the CancellationToken's WaitHandle:
+                token.ThrowIfCancellationRequested();
+                return;
+            }
+
             var tcs = new TaskCompletionSource<object>();
             using (token.Register(() => tcs.TrySetCanceled()))
             {
@@ -24,7 +41,7 @@ namespace Bluewire.Common.Console.Daemons
                         else tcs.TrySetResult(null);
                     },
                     null,
-                    limit,
+                    limitMilliseconds,
                     true);
 
                 await tcs.Task.ConfigureAwait(false);

--- a/Bluewire.Common.Console/Properties/AssemblyInfo.cs
+++ b/Bluewire.Common.Console/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Bluewire.Common.Console.UnitTests")]
 
-[assembly: AssemblyVersion("10.2.0")]
-[assembly: AssemblyFileVersion("10.2.0")]
+[assembly: AssemblyVersion("10.2.1")]
+[assembly: AssemblyFileVersion("10.2.1")]


### PR DESCRIPTION
Specify a negative timeout, instead of ~25 days.

Bluewire.Common.Console: 10.2.0 -> 10.2.1