### PR TITLE
Wait for start, instead of shutdown

### DIFF
--- a/Bluewire.Common.Console/Daemons/DaemonService.cs
+++ b/Bluewire.Common.Console/Daemons/DaemonService.cs
@@ -25,7 +25,8 @@ namespace Bluewire.Common.Console.Daemons
             session.Parse(staticArgs.Concat(args).ToArray());
 
             instance = new HostedDaemonMonitor<TArguments>(daemon);
-            instance.Start(session.Arguments).WaitWithUnwrapExceptions();
+            instance.Start(session.Arguments);
+            instance.WaitForStart();
         }
 
         protected override void OnStop()

--- a/Bluewire.Common.Console/Properties/AssemblyInfo.cs
+++ b/Bluewire.Common.Console/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Bluewire.Common.Console.UnitTests")]
 
-[assembly: AssemblyVersion("10.2.2")]
-[assembly: AssemblyFileVersion("10.2.2")]
+[assembly: AssemblyVersion("10.2.3")]
+[assembly: AssemblyFileVersion("10.2.3")]


### PR DESCRIPTION
The HostedDaemonMonitor's Start method returns a task representing the
whole lifetime of the service. When starting a service, OnStart should
only wait on startup.

Bluewire.Common.Console: 10.2.2 -> 10.2.3