### PR TITLE
If files are in use, GC and try again

### DIFF
--- a/Bluewire.Common.Console.NUnit3/Bluewire.Common.Console.NUnit3.csproj
+++ b/Bluewire.Common.Console.NUnit3/Bluewire.Common.Console.NUnit3.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
-    <VersionPrefix>9.2.1</VersionPrefix>
+    <VersionPrefix>9.2.2</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/Bluewire.Common.Console.NUnit3/Filesystem/PerTestTemporaryDirectoryAttribute.cs
+++ b/Bluewire.Common.Console.NUnit3/Filesystem/PerTestTemporaryDirectoryAttribute.cs
@@ -19,7 +19,18 @@ namespace Bluewire.Common.Console.NUnit3.Filesystem
             if (!Directory.Exists(temporaryPath)) return;
             if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed)
             {
-                FileSystemHelpers.CleanDirectory(temporaryPath);
+                try
+                {
+                    FileSystemHelpers.CleanDirectory(temporaryPath);
+                }
+                catch (IOException)
+                {
+                    // Some libraries release files during finalisation, not disposal. This is probably
+                    // most common with wrappers around native libraries.
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    FileSystemHelpers.CleanDirectory(temporaryPath);
+                }
             }
         }
 


### PR DESCRIPTION
Extend this behaviour to per-test teardown as well.

Bluewire.Common.Console.NUnit3: 9.2.1 -> 9.2.2